### PR TITLE
WIP PkgServer.jl private registry support

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -14,6 +14,11 @@ version = "1.3.0"
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[Cassette]]
+git-tree-sha1 = "742fbff99a2798f02bd37d25087efb5615b5a207"
+uuid = "7057c7e9-c182-5462-911a-8362d720325c"
+version = "0.3.5"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -132,6 +137,12 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
 uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 version = "1.1.0"
+
+[[SimpleMock]]
+deps = ["Cassette"]
+git-tree-sha1 = "0173cb8416512a56751055232d0b389d5c2d7175"
+uuid = "a896ed2c-15a5-4479-b61d-a0e88e2a1d25"
+version = "1.2.0"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ SimpleBufferStream = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 HTTP = "0.9"
@@ -27,7 +28,8 @@ SimpleBufferStream = "1.1"
 julia = "1.5"
 
 [extras]
+SimpleMock = "a896ed2c-15a5-4479-b61d-a0e88e2a1d25"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "SimpleMock"]

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -19,26 +19,6 @@ include("task_utils.jl")
 include("resource.jl")
 include("meta.jl")
 include("dynamic.jl")
-mutable struct RegistryMeta
-    # Upstream registry URL (e.g. "https://github.com/JuliaRegistries/General")
-    upstream_url::String
-    # The latest hash we know about for this registry
-    latest_hash::Union{Nothing,String}
-
-    function RegistryMeta(url::String)
-        # Check to ensure this path actually exists
-        if !url_exists(url)
-            throw(ArgumentError("Invalid unreachable registry '$(url)'"))
-        end
-
-        # Auto-detect a repository that doesn't have `.git` at the end but could
-        git_url = string(url, ".git")
-        if !endswith(url, ".git") && url_exists(git_url)
-            url = git_url
-        end
-        return new(url, nothing)
-    end
-end
 
 struct ServerConfig
     root::String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,10 @@ function prepare_for_deletion(path::AbstractString)
     end
 end
 
+# unit tests that do not require a running server
+@info("Running unit test suite.")
+include("unit_tests.jl")
+
 # If these are not set, we will attempt to auto-initiate them.
 server_process = nothing
 if isempty(get(ENV, "JULIA_PKG_SERVER", "")) || isempty(get(ENV, "JULIA_PKG_SERVER_STORAGE_ROOT", ""))

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1,0 +1,128 @@
+@testset "GitHub REST API URLs" begin
+    import PkgServer.GitHub
+
+    owner = "SomeOrg"
+    repo = "PrivateRegistry"
+    expected_api_repo_url = "https://api.github.com/repos/$owner/$repo"
+
+    # repository URL must be specified with or without ".git" suffix
+    @test GitHub.api_repository_url("https://github.com/$owner/$repo.git") == expected_api_repo_url
+    @test GitHub.api_repository_url("https://github.com/$owner/$repo") == expected_api_repo_url
+
+    # repository URL must be root
+    @test_throws DomainError GitHub.api_repository_url("https://github.com/JuliaRegistries/General/tree/master/")
+
+    # only GitHub-hosted repos are supported
+    @test_throws DomainError GitHub.api_repository_url("https://gitlab.com/$owner/$repo")
+    @test_throws DomainError GitHub.api_repository_url("https://git.example.com/$owner/$repo")
+
+    # tree SHA URL
+    sha = "46e44e869b4d90b96bd8ed1fdcf32244fddfb6cc"
+    @test GitHub.api_tree_url(expected_api_repo_url, sha) == expected_api_repo_url * "/git/trees/$sha"
+end
+
+@testset "GitHub.resource_exists()" begin
+    import PkgServer.GitHub
+    import HTTP
+    using SimpleMock
+
+    anyvalue = Predicate(_ -> true)
+
+    api_resource_url = "https://api.github.com/repos/SomeOrg/SomeRepo"
+    token = "simulated_token"
+
+    http_ok = HTTP.Response(200)
+
+    mock(HTTP.request => Mock((args...; kwargs...) -> http_ok)) do _request
+        # resource_exists() without token makes a HEAD request without Authorization header
+        @test GitHub.resource_exists(api_resource_url) == true
+        @test called_once_with(_request, "HEAD", api_resource_url, []; status_exception=false)
+
+        reset!(_request)
+
+        # resource_exists() with token makes a HEAD request with Authorization header
+        @test GitHub.resource_exists(api_resource_url, token=token) == true
+        @test called_once_with(_request, "HEAD", api_resource_url, ["Authorization" => "token $token"]; status_exception=false)
+    end
+
+    http_not_found = HTTP.Response(404)
+
+    mock(HTTP.request => Mock((args...; kwargs...) -> http_not_found)) do _request
+        # non-200 response indicates resource does not exist
+        @test GitHub.resource_exists(api_resource_url) == false
+        @test GitHub.resource_exists(api_resource_url; token=token) == false
+    end
+end
+
+@testset "RegistryMeta constructor" begin 
+    import PkgServer.GitHub, PkgServer.RegistryMeta
+    import HTTP
+    using SimpleMock
+
+    owner = "SomeOrg"
+    repo = "SomeRepo"
+    token = "simulated_token"
+
+    url_nogitsuffix = "https://github.com/$owner/$repo"
+    url_gitsuffix = "https://github.com/$owner/$repo.git"
+
+    expected_api_repo_url = "https://api.github.com/repos/$owner/$repo"
+
+    http_ok = HTTP.Response(200)
+
+    mock(HTTP.request => Mock((args...; kwargs...) -> http_ok)) do _request
+        #
+        # simulate a public registry that does not require an access token
+        #
+
+        meta1 = RegistryMeta(url_nogitsuffix)
+        @test meta1.upstream_url == url_nogitsuffix
+        @test meta1.upstream_api_url == expected_api_repo_url
+        @test meta1.access_token === nothing
+
+        # repo checked for accessibility without token
+        @test called_once_with(_request, "HEAD", expected_api_repo_url, []; status_exception=false)
+
+        reset!(_request)
+
+        meta2 = RegistryMeta(url_gitsuffix)
+        @test meta2.upstream_url == url_gitsuffix
+        @test meta2.upstream_api_url == expected_api_repo_url
+        @test meta2.access_token === nothing
+        
+        # repo checked for accessibility without token
+        @test called_once_with(_request, "HEAD", expected_api_repo_url, []; status_exception=false)
+
+        #
+        # simulate a private registry with a specified access token
+        #
+
+        reset!(_request)
+
+        meta3 = RegistryMeta(url_nogitsuffix, token=token)
+        @test meta3.upstream_url == url_nogitsuffix
+        @test meta3.upstream_api_url == expected_api_repo_url
+        @test meta3.access_token === token 
+
+        # repo checked for accessibility with token
+        @test called_once_with(_request, "HEAD", expected_api_repo_url, ["Authorization" => "token $token"]; status_exception=false)
+
+        reset!(_request)
+
+        meta4 = RegistryMeta(url_gitsuffix, token=token)
+        @test meta4.upstream_url == url_gitsuffix
+        @test meta4.upstream_api_url == expected_api_repo_url
+        @test meta4.access_token === token 
+
+        # repo checked for accessibility with token
+        @test called_once_with(_request, "HEAD", expected_api_repo_url, ["Authorization" => "token $token"]; status_exception=false)
+    end
+
+    http_not_found = HTTP.Response(404)
+
+    mock(HTTP.request => Mock((args...; kwargs...) -> http_not_found)) do _request
+        # GitHub API returns a 404 if a URL references a known registry but the token is invalid
+        # TODO: is DomainError more appropriate since this is not a signature mismatch but an invalid value?
+        @test_throws ArgumentError RegistryMeta(url_gitsuffix, token=token)
+    end
+end


### PR DESCRIPTION
@Roger-luo @GiggleLiu - would appreciate your feedback on my work-in-progress to add private registry support to PkgServer.jl

I still need to do some work to figure out how to specify repository configuration in the `bin/run_server.jl` script, but this branch demonstrates all of the implementation details to support private registries once you have the `PkgServer` instance running (I verified this running it locally in the REPL).

I added `test/unit_test.jl` for tests that do not require network connectivity. As Roger cautioned, SimpleMock.jl can be pretty slow, but it does allow me to write tests that verify desired HTTP requests to GitHub without making actual network requests that are dependent upon actual GitHub repos. staticfloat suggested that they could create a private registry for test purposes and integrate that into the tests which actually communicate with GitHub, but that will likely require some coordination and may not be in the pull request that I will open with upstream.

